### PR TITLE
Refactor logic for csv validation

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/dweepgogia/new-manifest-verification/pkg/validate"
+	"github.com/dweepgogia/new-manifest-verification/pkg/validate/validator"
+
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +28,8 @@ func verifyFunc(cmd *cobra.Command, args []string) {
 
 	yamlFileName := args[0]
 
-	if err := validate.ValidateCSVManifest(yamlFileName); err != nil {
+	// TODO: return a pointer instead
+	if err := validate.ValidateCSVManifest(yamlFileName); err != (validator.Error{}) {
 		fmt.Println(err)
 	}
 }

--- a/pkg/validate/csv_validator.go
+++ b/pkg/validate/csv_validator.go
@@ -1,7 +1,13 @@
 package validate
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/dweepgogia/new-manifest-verification/pkg/validate/validator"
+	"github.com/pkg/errors"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 )
@@ -38,4 +44,122 @@ func (v *CSVValidator) AddObjects(objs ...interface{}) validator.Error {
 
 func (v CSVValidator) Name() string {
 	return "ClusterServiceVersion Validator"
+}
+
+// Iterates over the given CSV. Returns a ManifestResult type object.
+func csvInspect(val interface{}) validator.ManifestResult {
+
+	fieldValue := reflect.ValueOf(val)
+
+	switch fieldValue.Kind() {
+	case reflect.Struct:
+		return checkMissingFields(fieldValue, "", validator.ManifestResult{})
+	default:
+		errs := []validator.Error{
+			validator.InvalidCSV("Error: input file is not a valid CSV."),
+		}
+
+		return validator.ManifestResult{Errors: errs, Warnings: nil}
+	}
+}
+
+// Recursive function that traverses a nested struct passed in as reflect value, and reports for errors/warnings
+// in case of null struct field values.
+func checkMissingFields(v reflect.Value, parentStructName string, log validator.ManifestResult) validator.ManifestResult {
+
+	for i := 0; i < v.NumField(); i++ {
+
+		fieldValue := v.Field(i)
+
+		tag := v.Type().Field(i).Tag.Get("json")
+		// Ignore fields that are subsets of a primitive field.
+		if tag == "" {
+			continue
+		}
+
+		fields := strings.Split(tag, ",")
+		isOptionalField := containsStrict(fields, "omitempty")
+		emptyVal := isEmptyValue(fieldValue)
+
+		newParentStructName := ""
+		if parentStructName == "" {
+			newParentStructName = v.Type().Field(i).Name
+		} else {
+			newParentStructName = parentStructName + "." + v.Type().Field(i).Name
+		}
+
+		switch fieldValue.Kind() {
+		case reflect.Struct:
+			log = updateLog(log, "Struct", newParentStructName, emptyVal, isOptionalField)
+			if emptyVal {
+				continue
+			}
+			log = checkMissingFields(fieldValue, newParentStructName, log)
+		default:
+			log = updateLog(log, "Field", newParentStructName, emptyVal, isOptionalField)
+		}
+	}
+	return log
+}
+
+// Returns updated error log with missing optional/mandatory field/struct objects.
+func updateLog(log validator.ManifestResult, typeName string, newParentStructName string, emptyVal bool, isOptionalField bool) validator.ManifestResult {
+
+	if emptyVal && isOptionalField {
+		err := errors.Errorf("Warning: Optional %s Missing", typeName)
+		// TODO: update the value field (typeName).
+		log.Warnings = append(log.Warnings, validator.OptionalFieldMissing(newParentStructName, typeName, err.Error()))
+	} else if emptyVal && !isOptionalField {
+		if newParentStructName != "Status" {
+			err := errors.Errorf("Error: Mandatory %s Missing", typeName)
+			// TODO: update the value field (typeName).
+			log.Errors = append(log.Errors, validator.MandatoryFieldMissing(newParentStructName, typeName, err.Error()))
+		}
+	}
+	return log
+}
+
+// Takes in a string slice and checks if a string (x) is present in the slice.
+// Return true if the string is present in the slice.
+func containsStrict(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+// Uses reflect package to check if the value of the object passed is null, returns a boolean accordingly.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		// Check if the value for 'Spec.InstallStrategy.StrategySpecRaw' field is present. This field is a RawMessage value type. Without a value, the key is explicitly set to 'null'.
+		if fieldValue, ok := v.Interface().(json.RawMessage); ok {
+			valString := string(fieldValue)
+			if valString == "null" {
+				return true
+			}
+		}
+		return v.Len() == 0
+	// Currently the only CSV field with integer type is containerPort. Operator Verification Library raises a warning if containerPort field is missisng or if its value is 0.
+	// It is an optional field so the user can ignore the warning saying this field is missing if they intend to use port 0.
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	case reflect.Struct:
+		for i, n := 0, v.NumField(); i < n; i++ {
+			if !isEmptyValue(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		panic(fmt.Sprintf("%v kind is not supported.", v.Kind()))
+	}
 }

--- a/pkg/validate/csv_validator.go
+++ b/pkg/validate/csv_validator.go
@@ -24,7 +24,7 @@ func (v *CSVValidator) Validate() (results []validator.ManifestResult) {
 	return results
 }
 
-func (v *CSVValidator) AddObjects(objs ...interface{}) error {
+func (v *CSVValidator) AddObjects(objs ...interface{}) validator.Error {
 	for _, o := range objs {
 		switch t := o.(type) {
 		case olm.ClusterServiceVersion:
@@ -33,7 +33,7 @@ func (v *CSVValidator) AddObjects(objs ...interface{}) error {
 			v.csvs = append(v.csvs, *t)
 		}
 	}
-	return nil
+	return validator.Error{}
 }
 
 func (v CSVValidator) Name() string {

--- a/pkg/validate/serialize.go
+++ b/pkg/validate/serialize.go
@@ -4,14 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"reflect"
-	"strings"
 
 	"github.com/dweepgogia/new-manifest-verification/pkg/validate/validator"
 
 	"github.com/ghodss/yaml"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"github.com/pkg/errors"
 )
 
 // ValidateCSVManifest takes in name of the yaml file to be validated, reads
@@ -81,124 +78,5 @@ func unmarshal(rawYAML []byte) (olm.ClusterServiceVersion, error) {
 	if err := json.Unmarshal(rawJson, &csv); err != nil {
 		return olm.ClusterServiceVersion{}, fmt.Errorf("error parsing CSV list (JSON) : %s", err)
 	}
-
 	return csv, nil
-}
-
-// Iterates over the given CSV. Returns a ManifestResult type object.
-func csvInspect(val interface{}) validator.ManifestResult {
-
-	fieldValue := reflect.ValueOf(val)
-
-	switch fieldValue.Kind() {
-	case reflect.Struct:
-		return checkMissingFields(fieldValue, "", validator.ManifestResult{})
-	default:
-		errs := []validator.Error{
-			validator.InvalidCSV("Error: input file is not a valid CSV."),
-		}
-
-		return validator.ManifestResult{Errors: errs, Warnings: nil}
-	}
-}
-
-// Takes in a string slice and checks if a string (x) is present in the slice.
-// Return true if the string is present in the slice.
-func containsStrict(a []string, x string) bool {
-	for _, n := range a {
-		if x == n {
-			return true
-		}
-	}
-	return false
-}
-
-// Recursive function that traverses a nested struct passed in as reflect value, and reports for errors/warnings
-// in case of null struct field values.
-func checkMissingFields(v reflect.Value, parentStructName string, log validator.ManifestResult) validator.ManifestResult {
-
-	for i := 0; i < v.NumField(); i++ {
-
-		fieldValue := v.Field(i)
-
-		tag := v.Type().Field(i).Tag.Get("json")
-		// Ignore fields that are subsets of a primitive field.
-		if tag == "" {
-			continue
-		}
-
-		fields := strings.Split(tag, ",")
-		isOptionalField := containsStrict(fields, "omitempty")
-		emptyVal := isEmptyValue(fieldValue)
-
-		newParentStructName := ""
-		if parentStructName == "" {
-			newParentStructName = v.Type().Field(i).Name
-		} else {
-			newParentStructName = parentStructName + "." + v.Type().Field(i).Name
-		}
-
-		switch fieldValue.Kind() {
-		case reflect.Struct:
-			log = updateLog(log, "Struct", newParentStructName, emptyVal, isOptionalField)
-			if emptyVal {
-				continue
-			}
-			log = checkMissingFields(fieldValue, newParentStructName, log)
-		default:
-			log = updateLog(log, "Field", newParentStructName, emptyVal, isOptionalField)
-		}
-	}
-	return log
-}
-
-// Returns updated error log with missing optional/mandatory field/struct objects.
-func updateLog(log validator.ManifestResult, typeName string, newParentStructName string, emptyVal bool, isOptionalField bool) validator.ManifestResult {
-
-	if emptyVal && isOptionalField {
-		err := errors.Errorf("Warning: Optional %s Missing", typeName)
-		// TODO: update the value field (typeName).
-		log.Warnings = append(log.Warnings, validator.OptionalFieldMissing(newParentStructName, typeName, err.Error()))
-	} else if emptyVal && !isOptionalField {
-		if newParentStructName != "Status" {
-			err := errors.Errorf("Error: Mandatory %s Missing", typeName)
-			// TODO: update the value field (typeName).
-			log.Errors = append(log.Errors, validator.MandatoryFieldMissing(newParentStructName, typeName, err.Error()))
-		}
-	}
-	return log
-}
-
-// Uses reflect package to check if the value of the object passed is null, returns a boolean accordingly.
-func isEmptyValue(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
-		// Check if the value for 'Spec.InstallStrategy.StrategySpecRaw' field is present. This field is a RawMessage value type. Without a value, the key is explicitly set to 'null'.
-		if fieldValue, ok := v.Interface().(json.RawMessage); ok {
-			valString := string(fieldValue)
-			if valString == "null" {
-				return true
-			}
-		}
-		return v.Len() == 0
-	// Currently the only CSV field with integer type is containerPort. Operator Verification Library raises a warning if containerPort field is missisng or if its value is 0.
-	// It is an optional field so the user can ignore the warning saying this field is missing if they intend to use port 0.
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
-		return v.IsNil()
-	case reflect.Struct:
-		for i, n := 0, v.NumField(); i < n; i++ {
-			if !isEmptyValue(v.Field(i)) {
-				return false
-			}
-		}
-		return true
-	default:
-		panic(fmt.Sprintf("%v kind is not supported.", v.Kind()))
-	}
 }

--- a/pkg/validate/validateSchema.go
+++ b/pkg/validate/validateSchema.go
@@ -1,0 +1,199 @@
+// The static validators defined in this file are taken as is
+// from the operator-registry's codebase which can be found here
+// https://github.com/operator-framework/operator-registry/blob/master/pkg/schema/schema.go
+//
+// Returned error types have been changed to generic error type defined by the
+// Operator Verification Library.
+
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
+	apiservervalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/dweepgogia/new-manifest-verification/pkg/validate/validator"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func ValidateCRD(schemaFileName string, fileBytes []byte) *validator.ManifestResult {
+	schemaBytes, err := ioutil.ReadFile(schemaFileName)
+	if err != nil {
+		return getManifestResult(validator.IOError(fmt.Sprintf("Error in reading %s file:  #%s ", schemaFileName, err), schemaFileName))
+	}
+	schemaBytesJson, err := yaml.YAMLToJSON(schemaBytes)
+	if err != nil {
+		return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing raw YAML to Json for %s file:  #%s ", schemaFileName, err), schemaFileName))
+	}
+
+	crd := v1beta1.CustomResourceDefinition{}
+	json.Unmarshal(schemaBytesJson, &crd)
+
+	exampleFileBytesJson, err := yaml.YAMLToJSON(fileBytes)
+	if err != nil {
+		return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing raw YAML to Json for fileBytes:  #%s ", err), ""))
+	}
+	unstructured := unstructured.Unstructured{}
+	err = json.Unmarshal(exampleFileBytesJson, &unstructured)
+	if err != nil {
+		return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing unstructured Json bytes to %s:  #%s ", unstructured, err), ""))
+	}
+
+	// Validate CRD definition statically
+	scheme := runtime.NewScheme()
+	err = apiextensions.AddToScheme(scheme)
+	if err != nil {
+		return getManifestResult(validator.InvalidOperation(fmt.Sprintf("Error adding scheme:  #%s ", err))) // TODO: See if we need a specific function for these errors.
+	}
+	err = v1beta1.AddToScheme(scheme)
+	if err != nil {
+		return getManifestResult(validator.InvalidOperation(fmt.Sprintf("Error adding scheme:  #%s ", err))) // TODO: See if we need a specific function for these errors.
+	}
+
+	unversionedCRD := apiextensions.CustomResourceDefinition{}
+	scheme.Converter().Convert(&crd, &unversionedCRD, conversion.SourceToDest, nil)
+	errList := validation.ValidateCustomResourceDefinition(&unversionedCRD)
+	if len(errList) > 0 {
+		castErrList := []validator.Error{}
+		for _, ferr := range errList {
+			err := validator.Error{Type: validator.ErrorType(ferr.Type), Field: ferr.Field, BadValue: ferr.BadValue, Detail: ferr.Detail}
+			castErrList = append(castErrList, err)
+		}
+		castErrList = append(castErrList, validator.FailedValidation(fmt.Sprintf("CRD failed validation: %s.", schemaFileName), schemaFileName))
+		return &validator.ManifestResult{Errors: castErrList, Warnings: nil}
+	}
+
+	// Validate CR against CRD schema
+	newSchemaValidator, _, err := apiservervalidation.NewSchemaValidator(unversionedCRD.Spec.Validation)
+	err = apiservervalidation.ValidateCustomResource(unstructured.UnstructuredContent(), newSchemaValidator)
+	if err != nil {
+		return getManifestResult(validator.FailedValidation(err.Error(), schemaFileName))
+	}
+	return &validator.ManifestResult{}
+}
+
+func getManifestResult(errs ...validator.Error) *validator.ManifestResult {
+	errList := append([]validator.Error{}, errs...)
+	return &validator.ManifestResult{Errors: errList, Warnings: nil}
+}
+
+func ValidateKind(kind string, fileBytes []byte) *validator.ManifestResult {
+	exampleFileBytesJson, err := yaml.YAMLToJSON(fileBytes)
+	if err != nil {
+		return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing raw YAML to Json for fileBytes:  #%s ", err), ""))
+	}
+
+	switch kind {
+	case "ClusterServiceVersion":
+		csv := v1alpha1.ClusterServiceVersion{}
+		err = json.Unmarshal(exampleFileBytesJson, &csv)
+		if err != nil {
+			return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing unstructured Json bytes to %T:  #%s ", csv, err), ""))
+		}
+		err := validateExamplesAnnotations(&csv)
+		if err != nil {
+			return err
+		}
+		return nil
+	case "CatalogSource":
+		cs := v1alpha1.CatalogSource{}
+		err = json.Unmarshal(exampleFileBytesJson, &cs)
+		if err != nil {
+			return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing unstructured Json bytes to %T:  #%s ", cs, err), ""))
+		}
+		return nil
+	default:
+		return getManifestResult(validator.InvalidOperation(fmt.Sprintf("Error didn't recognize validate-kind directive: %s", kind)))
+	}
+}
+
+func validateExamplesAnnotations(csv *v1alpha1.ClusterServiceVersion) *validator.ManifestResult {
+	var examples []v1beta1.CustomResourceDefinition
+	var annotationsNames = []string{"alm-examples", "olm.examples"}
+	var annotationsExamples string
+	var ok bool
+	annotations := csv.ObjectMeta.GetAnnotations()
+	// Return right away if no examples annotations are found.
+	if annotations == nil {
+		return &validator.ManifestResult{}
+	}
+	// Expect either `alm-examples` or `old.examples` but not both
+	// If both are present, `alm-examples` will be used
+	for _, name := range annotationsNames {
+		annotationsExamples, ok = annotations[name]
+		if ok {
+			break
+		}
+	}
+
+	// Can't find examples annotations, simply return
+	if annotationsExamples == "" {
+		return &validator.ManifestResult{}
+	}
+
+	if err := json.Unmarshal([]byte(annotationsExamples), &examples); err != nil {
+		return getManifestResult(validator.InvalidParse(fmt.Sprintf("Error parsing unstructured Json bytes to %T:  #%s ", examples, err), ""))
+	}
+
+	providedAPIs, err := getProvidedAPIs(csv)
+	if err != nil {
+		return err
+	}
+	parsedExamples, err := parseExamplesAnnotations(examples)
+	if err != nil {
+		return err
+	}
+	if matchGVKProvidedAPIs(parsedExamples, providedAPIs) != nil {
+		return err
+	}
+	return nil
+}
+
+func getProvidedAPIs(csv *v1alpha1.ClusterServiceVersion) (map[schema.GroupVersionKind]struct{}, *validator.ManifestResult) {
+	provided := map[schema.GroupVersionKind]struct{}{}
+
+	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
+		parts := strings.SplitN(owned.Name, ".", 2)
+		if len(parts) < 2 {
+			return nil, getManifestResult(validator.InvalidParse(fmt.Sprintf("Error couldn't parse plural.group from crd name: %s", owned.Name), owned.Name))
+		}
+		provided[schema.GroupVersionKind{Group: parts[1], Version: owned.Version, Kind: owned.Kind}] = struct{}{}
+	}
+
+	for _, api := range csv.Spec.APIServiceDefinitions.Owned {
+		provided[schema.GroupVersionKind{Group: api.Group, Version: api.Version, Kind: api.Kind}] = struct{}{}
+	}
+	return provided, nil
+}
+
+func parseExamplesAnnotations(examples []v1beta1.CustomResourceDefinition) (map[schema.GroupVersionKind]struct{}, *validator.ManifestResult) {
+	parsed := map[schema.GroupVersionKind]struct{}{}
+	for _, value := range examples {
+		parts := strings.SplitN(value.APIVersion, "/", 2)
+		if len(parts) < 2 {
+			return nil, getManifestResult(validator.InvalidParse(fmt.Sprintf("Error couldn't parse group/version from crd kind: %s", value.Kind), value))
+		}
+		parsed[schema.GroupVersionKind{Group: parts[0], Version: parts[1], Kind: value.Kind}] = struct{}{}
+	}
+	return parsed, nil
+}
+
+func matchGVKProvidedAPIs(examples map[schema.GroupVersionKind]struct{}, providedAPIs map[schema.GroupVersionKind]struct{}) *validator.ManifestResult {
+	for key := range examples {
+		if _, ok := providedAPIs[key]; !ok {
+			return getManifestResult(validator.FailedValidation(fmt.Sprintf("Error couldn't match %v in provided APIs list: %v", key, providedAPIs), providedAPIs))
+		}
+	}
+	return nil
+}

--- a/pkg/validate/validator/interface.go
+++ b/pkg/validate/validator/interface.go
@@ -6,10 +6,11 @@ package validator
 type Validator interface {
 	// Validate should run validation logic on an arbitrary object, and return
 	// a one ManifestResult for each object that did not pass validation.
+	// TODO: use pointers
 	Validate() []ManifestResult
 	// AddObjects adds objects to the Validator. Each object will be validated
 	// when Validate() is called.
-	AddObjects(...interface{}) error
+	AddObjects(...interface{}) Error
 	// Name should return a succinct name for this validator.
 	Name() string
 }

--- a/pkg/validate/validator/validator.go
+++ b/pkg/validate/validator/validator.go
@@ -31,7 +31,7 @@ type Error struct {
 }
 
 func (err Error) String() string {
-	return fmt.Sprintf("Error type: %s | Field: %s | Value: %v | Detail: %s", err.Type, err.Field, err.BadValue, err.Detail)
+	return fmt.Sprintf("Detail: %s | Error type: %s | Value: %v | Field: %s", err.Detail, err.Type.String(), err.BadValue, err.Field)
 }
 
 type ErrorType string
@@ -79,6 +79,30 @@ const (
 	ErrorFailedValidation ErrorType = "ValidationFailed"
 	ErrorInvalidOperation ErrorType = "OperationFailed"
 )
+
+// String converts a ErrorType into its corresponding canonical error message.
+func (t ErrorType) String() string {
+	switch t {
+	case ErrorInvalidCSV:
+		return "CSV file not valid"
+	case WarningFieldMissing:
+		return "Optional field not found"
+	case ErrorFieldMissing:
+		return "Mandatory field not found"
+	case ErrorUnsupportedType:
+		return "Field type not supported"
+	case ErrorInvalidParse:
+		return "Unmarshall/Parse error"
+	case ErrorIO:
+		return "File read error"
+	case ErrorFailedValidation:
+		return "Validation failed"
+	case ErrorInvalidOperation:
+		return "Operation failed"
+	default:
+		panic(fmt.Sprintf("Unrecognized validation error: %q", string(t)))
+	}
+}
 
 // Error strut implements the 'error' interface to define custom error formatting.
 func (err Error) Error() string {

--- a/pkg/validate/validator/validator.go
+++ b/pkg/validate/validator/validator.go
@@ -9,31 +9,80 @@ type ManifestResult struct {
 	// usually be set to object.GetName().
 	Name string
 	// Errors pertain to issues with the manifest that must be corrected.
-	Errors []MissingTypeError
+	Errors []Error
 	// Warnings pertain to issues with the manifest that are optional to correct.
-	Warnings []MissingTypeError
+	Warnings []Error
 }
 
-// MissingTypeError represents a warning or an error in a yaml file.
-type MissingTypeError struct {
-	// Err is the underlying error caused by a missing type, if any.
-	Err error
-	// TypeName is the syntactical name of missing data, ex. Struct, Field.
-	TypeName string
-	// Path is the dot-hierarchical YAML path of the missing data.
-	Path string
-	// IsMandatory determines whether the missing data should generate a
-	// warning (false, the default) or error (true).
-	IsMandatory bool
+// Error is an implementation of the 'error' interface, which represents a
+// warning or an error in a yaml file. Error type is taken as is from
+// https://github.com/operator-framework/operator-registry/blob/master/vendor/k8s.io/apimachinery/pkg/util/validation/field/errors.go#L31
+// to maintain compatibility with upstream.
+type Error struct {
+	// Type is the ErrorType string constant that represents the kind of
+	// error, ex. "MandatoryStructMissing", "I/O".
+	Type ErrorType
+	// Field is the dot-hierarchical YAML path of the missing data.
+	Field string
+	// BadValue is the field or file that caused an error or warning.
+	BadValue interface{}
+	// Detail represents the error message as a string.
+	Detail string
 }
 
-// MissingTypeError strut implements the Error interface to define custom error formatting.
-func (err MissingTypeError) Error() string {
-	if err.IsMandatory {
-		return fmt.Sprintf("Error: Mandatory %s Missing (%s)", err.TypeName, err.Path)
-	} else {
-		return fmt.Sprintf("Warning: Optional %s Missing (%s)", err.TypeName, err.Path)
-	}
+func (err Error) String() string {
+	return fmt.Sprintf("Error type: %s | Field: %s | Value: %v | Detail: %s", err.Type, err.Field, err.BadValue, err.Detail)
+}
+
+type ErrorType string
+
+func InvalidCSV(detail string) Error {
+	return Error{ErrorInvalidCSV, "", "", detail}
+}
+
+func OptionalFieldMissing(field string, value interface{}, detail string) Error {
+	return Error{WarningFieldMissing, field, value, detail}
+}
+
+func MandatoryFieldMissing(field string, value interface{}, detail string) Error {
+	return Error{ErrorFieldMissing, field, value, detail}
+}
+
+func UnsupportedType(detail string) Error {
+	return Error{ErrorUnsupportedType, "", "", detail}
+}
+
+// TODO: see if more information can be extracted out of 'unmarshall/parsing' errors.
+func InvalidParse(detail string, value interface{}) Error {
+	return Error{ErrorInvalidParse, "", value, detail}
+}
+
+func IOError(detail string, value interface{}) Error {
+	return Error{ErrorIO, "", value, detail}
+}
+
+func FailedValidation(detail string, value interface{}) Error {
+	return Error{ErrorFailedValidation, "", value, detail}
+}
+
+func InvalidOperation(detail string) Error {
+	return Error{ErrorInvalidOperation, "", "", detail}
+}
+
+const (
+	ErrorInvalidCSV       ErrorType = "CSVFileNotValid"
+	WarningFieldMissing   ErrorType = "OptionalFieldNotFound"
+	ErrorFieldMissing     ErrorType = "MandatoryFieldNotFound"
+	ErrorUnsupportedType  ErrorType = "FieldTypeNotSupported"
+	ErrorInvalidParse     ErrorType = "Unmarshall/ParseError"
+	ErrorIO               ErrorType = "FileReadError"
+	ErrorFailedValidation ErrorType = "ValidationFailed"
+	ErrorInvalidOperation ErrorType = "OperationFailed"
+)
+
+// Error strut implements the 'error' interface to define custom error formatting.
+func (err Error) Error() string {
+	return err.Detail
 }
 
 // ValidatorSet contains a set of Validators to be executed sequentially.


### PR DESCRIPTION
To have all the CSV checks in one file (csv_validator.go).